### PR TITLE
fix: app store and play store badges

### DIFF
--- a/www/src/components/QRCode/index.tsx
+++ b/www/src/components/QRCode/index.tsx
@@ -4,8 +4,8 @@ import { QrCodeObject, Link as LinkType, Maybe } from '@/types/sanity';
 import { SanityImage } from '@/atoms/Image/SanityImage';
 import { GenericImage } from '@/atoms/Image/GenericImage';
 import { Link } from '@/atoms/Link';
-import googlePlayStoreBadge from '@/assets/images/google-play-store-badge.png';
-import appStoreBadge from '@/assets/images/app-store-badge.png';
+import googlePlayStoreBadge from '../../assets/images/google-play-store-badge.png';
+import appStoreBadge from '../../assets/images/app-store-badge.png';
 import {
   QrCodeSmallImageLink,
   QrCodeWrapper,
@@ -21,11 +21,12 @@ const StoreImage: FC<{
   const isAppStore = store === 'appStore';
   const image = isAppStore ? appStoreBadge : googlePlayStoreBadge;
   return (
-    <GenericImage
-      aspectRatio={image.height / image.width}
-      src={image}
+    <img
+      src={image.src}
+      width={image.width}
+      height={image.height}
       alt={isAppStore ? 'App store image' : 'Google play store image'}
-      sizes={['135px']}
+      sizes={'135px'}
     />
   );
 };


### PR DESCRIPTION
### Description

Fixes `QRCode` to render app store and play store badges

### Applicable screenshots or Loom video

Desktop
![Screenshot 2024-05-20 at 6 21 37 PM](https://github.com/fireflyhealth/marketing-website/assets/94393474/0ce251ad-a973-4825-988c-295e7dcb6931)

Mobile
![Screenshot 2024-05-20 at 6 21 48 PM](https://github.com/fireflyhealth/marketing-website/assets/94393474/df35906c-5e5f-4213-b3c3-572f54df86c9)