### PR TITLE
Use startsWith() instead of exact match for JPMC url check

### DIFF
--- a/www/src/pages/with/[clientSlug]/index.tsx
+++ b/www/src/pages/with/[clientSlug]/index.tsx
@@ -28,7 +28,7 @@ const ClientPage: FC<ClientPageProps> = ({ siteSettings, clientPage }) => {
     jpmcUserFlowVideo,
   } = siteSettings;
   const router = useRouter();
-  const isJPMCPage = router.asPath === '/with/jpmc/';
+  const isJPMCPage = router.asPath.startsWith('/with/jpmc');
   return (
     <>
       {showOriginalJPMCPage && isJPMCPage ? (


### PR DESCRIPTION
### Description

Shaly noticed an issue where the wrong version of the JPMC page is loaded when the `redirect=true` query parameter is present. This is because of the strict equivalence check we perform to determine whether to load the JPMC page.

I'm fixing this by just checking whether the URL starts with the expected substring rather than doing an exact match.
