### PR TITLE
feat: create hubspot form block

### DIFF
--- a/sanity/lib/constants.ts
+++ b/sanity/lib/constants.ts
@@ -120,6 +120,7 @@ export const defaultContentBlockTypes = [
   { type: 'testimonialBlock' },
   { type: 'doubleCtaBlock' },
   { type: 'twoUpBlock' },
+  { type: 'hubspotFormBlock' },
 ];
 
 /**

--- a/sanity/schemas/blocks/hubspotFormBlock.ts
+++ b/sanity/schemas/blocks/hubspotFormBlock.ts
@@ -1,0 +1,28 @@
+import { defineType, defineField } from 'sanity';
+import { icons } from '../../lib/icons';
+import { requiredBlockFields } from './utils/requiredBlockFields';
+
+export const HubspotFormBlock = defineType({
+  name: 'hubspotFormBlock',
+  title: 'Hubspot Form Block',
+  type: 'object',
+  icon: icons.Hubspot,
+  fields: [
+    ...requiredBlockFields,
+    defineField({
+      name: 'form',
+      title: 'Form',
+      type: 'hubspotForm',
+      validation: (Rule) => Rule.required(),
+    }),
+  ],
+  preview: {
+    select: {
+      header: 'header',
+    },
+    prepare: ({ header }) => ({
+      title: 'Hubspot Form Block',
+      subtitle: header?.title || null,
+    }),
+  },
+});

--- a/sanity/schemas/index.ts
+++ b/sanity/schemas/index.ts
@@ -57,6 +57,7 @@ import { DividerBlock } from './blocks/dividerBlock';
 import { VideoBlock } from './blocks/videoBlock';
 import { ProviderPhilosophyBlock } from './blocks/providerPhilosophyBlock';
 import { NearbyBlock } from './blocks/nearbyBlock';
+import { HubspotFormBlock } from './blocks/hubspotFormBlock';
 
 /* Fields */
 import { Metadata } from './fields/metadata';
@@ -169,6 +170,7 @@ export const schemaTypes = [
   DividerBlock,
   VideoBlock,
   ProviderPhilosophyBlock,
+  HubspotFormBlock,
 
   /* Child blocks (used within other blocks, i.e. 2-up block) */
   CtaCard,

--- a/www/src/components/contentBlocks/ContentArea/index.tsx
+++ b/www/src/components/contentBlocks/ContentArea/index.tsx
@@ -31,6 +31,7 @@ import { SmallImageCarouselBlock } from '../SmallImageCarouselBlock';
 import { VideoBlock } from '../VideoBlock';
 import { ProviderPhilosophyBlock } from '../ProviderPhilosophyBlock';
 import { NearbyBlock } from '../NearbyBlock';
+import { HubspotFormBlock } from '../HubspotFormBlock';
 
 type ContentBlockProps = {
   block: ContentBlockType;
@@ -84,6 +85,8 @@ const ContentBlock: FC<ContentBlockProps> = ({ block }) => {
       return <ProviderPhilosophyBlock providerPhilosophyBlock={block} />;
     case 'nearbyBlock':
       return <NearbyBlock nearbyBlock={block} />;
+    case 'hubspotFormBlock':
+      return <HubspotFormBlock hubspotFormBlock={block} />;
     default:
       console.warn(
         // @ts-expect-error

--- a/www/src/components/contentBlocks/HubspotFormBlock/index.tsx
+++ b/www/src/components/contentBlocks/HubspotFormBlock/index.tsx
@@ -1,0 +1,20 @@
+import React, { FC } from 'react';
+import { HubspotFormBlock as HubspotFormBlockType } from '@/types/sanity';
+import HubspotForm from '@/components/HubspotForm';
+import { ContentBlockWrapper } from '../ContentBlockWrapper';
+
+type FeaturedStoriesBlockProps = {
+  hubspotFormBlock: HubspotFormBlockType;
+};
+
+export const HubspotFormBlock: FC<FeaturedStoriesBlockProps> = ({
+  hubspotFormBlock,
+}) => {
+  const { header, form, subnav } = hubspotFormBlock;
+
+  return (
+    <ContentBlockWrapper id={subnav?.contentBlockId} header={header}>
+      <HubspotForm formId={form.formId} renderInRichtext />
+    </ContentBlockWrapper>
+  );
+};

--- a/www/src/lib/sanity/queries/fragments.ts
+++ b/www/src/lib/sanity/queries/fragments.ts
@@ -726,6 +726,13 @@ export const nearbyBlockFragment = `
   ...
 `;
 
+export const hubspotFormBlockFragment = `
+  form {
+    _type,
+    formId
+  }
+`;
+
 /* Please keep this alphabetized! */
 export const contentBlockFragment = `
   _type,
@@ -754,7 +761,8 @@ export const contentBlockFragment = `
   _type == "twoUpBlock" => {${twoUpBlockFragment}},
   _type == "videoBlock" => {${videoBlockFragment}},
   _type == "providerPhilosophyBlock" => {${providerPhilosophyBlockFragment}},
-  _type == "nearbyBlock" => {${nearbyBlockFragment}}
+  _type == "nearbyBlock" => {${nearbyBlockFragment}},
+  _type == "hubspotFormBlock" => {${hubspotFormBlockFragment}}
 `;
 
 export const videoHeaderFragment = `

--- a/www/src/types/sanity.ts
+++ b/www/src/types/sanity.ts
@@ -760,7 +760,8 @@ export type ContentBlock =
   | DividerBlock
   | VideoBlock
   | ProviderPhilosophyBlock
-  | NearbyBlock;
+  | NearbyBlock
+  | HubspotFormBlock;
 
 export type ContentArea = KeyedArray<ContentBlock>;
 
@@ -1035,4 +1036,9 @@ export type NearbyBlock = ContentBlockCommon & {
   mobileAspectRatio?: Maybe<AspectRatio>;
   tabletAspectRatio?: Maybe<AspectRatio>;
   desktopAspectRatio?: Maybe<AspectRatio>;
+};
+
+export type HubspotFormBlock = ContentBlockCommon & {
+  _type: 'hubspotFormBlock';
+  form: HubspotForm;
 };


### PR DESCRIPTION
### Description

- Creates `Hubspot Form Block` content block

Addresses this [maintenance ticket](https://www.notion.so/garden3d/a2ad8d447b914caa95ba0f01214ed512?v=69f7a661391d40eb966fce5affc5720c&p=9d31d5c241784706b7ec20733eb04dc5&pm=s)

### QA Instructions

Test on `/test-page` (staging)

### Applicable screenshots or Loom video
![Screenshot 2024-08-05 at 12 44 38 PM](https://github.com/user-attachments/assets/ad73f61a-f3c3-4bde-9a12-aae88d5c2c58)
![Screenshot 2024-08-05 at 12 44 45 PM](https://github.com/user-attachments/assets/a04c4e54-bc82-4ef5-9eb3-89dfbd37e0be)

![Screenshot 2024-08-05 at 12 44 07 PM](https://github.com/user-attachments/assets/fbf479f4-ce13-4e3d-8da0-26e99397ec35)