### PR TITLE
requested update: remove signup button on JPMC page

### DIFF
--- a/www/src/views/JPMCView/index.tsx
+++ b/www/src/views/JPMCView/index.tsx
@@ -147,13 +147,6 @@ export const JPMCVIew: FC<Props> = ({
                         <div className="margin-top margin-small">
                           <div className="button-group">
                             <a
-                              href="https://members.firefly.health/signup/name/jpmc?__hstc=252151062.47674a4132cb4b01dbe02bd48a59ff3b.1712252519733.1714413294344.1714491221475.12&__hssc=252151062.1.1714491221475&__hsfp=1245837078"
-                              target="_blank"
-                              className="button button-size-large w-button !w-1/2"
-                            >
-                              Sign up today
-                            </a>
-                            <a
                               href="#video-section"
                               className="button button-size-large w-button !w-1/2"
                             >
@@ -391,25 +384,6 @@ export const JPMCVIew: FC<Props> = ({
                                 assess your concerns, create a plan, and check
                                 your progress along the way.
                               </p>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="container-medium">
-                    <div className="animation-third">
-                      <div className="text-align-center">
-                        <div className="margin-top margin-small">
-                          <div className="text-align-center">
-                            <div className="margin-top margin-medium">
-                              <a
-                                href="https://members.firefly.health/signup/name/jpmc?__hstc=252151062.47674a4132cb4b01dbe02bd48a59ff3b.1712252519733.1714413294344.1714491221475.12&__hssc=252151062.1.1714491221475&__hsfp=1245837078"
-                                target="_blank"
-                                className="button button-size-large w-button"
-                              >
-                                Sign up today
-                              </a>
                             </div>
                           </div>
                         </div>
@@ -764,19 +738,6 @@ export const JPMCVIew: FC<Props> = ({
                               Sign up online and get our app, choose your care
                               team, and book your first visit.
                             </div>
-                          </div>
-                        </div>
-                      </div>
-                      <div className="animation-second">
-                        <div className="text-align-center">
-                          <div className="margin-top margin-medium">
-                            <a
-                              href="https://members.firefly.health/signup/name/jpmc?__hstc=252151062.47674a4132cb4b01dbe02bd48a59ff3b.1712252519733.1714413294344.1714491221475.12&__hssc=252151062.1.1714491221475&__hsfp=1245837078"
-                              target="_blank"
-                              className="button button-size-large w-button"
-                            >
-                              Sign up!
-                            </a>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
### Description
remove signup buttons on JPMC page.

### QA Instructions

<!--- If you'd like reviewers to test locally, please add steps here -->

### Applicable screenshots or Loom video
please disregard navigation. screenshot was using dev env CMS. 
![screencapture-localhost-3000-with-jpmc-2024-10-22-16_31_28](https://github.com/user-attachments/assets/ba740621-b57b-4a5e-970b-652cdd482140)
![screencapture-localhost-3000-with-jpmc-2024-10-22-16_32_19](https://github.com/user-attachments/assets/b5298366-ed97-4bd1-b7e9-b54b2399ec95)
![screencapture-localhost-3000-with-jpmc-2024-10-22-16_32_48](https://github.com/user-attachments/assets/aba44295-90d7-4ae8-a572-4fc89d09c7f3)

<!--- When appropriate, upload screenshots or link to a Loom. -->

<!--
for frontend PRs, you can use this table to put screengrabs & figma designs side-by-side. This can be a chore but is great for catching things you might have missed!

Github will insert line breaks when you paste in an image, so you'll need to do a bit of reformatting to get it to look like:

| <img width="350" ...> | <img width="350" ...> |

Tip: Set the "width" attribute manually to force column widths to match
-->

<!--
| Screenshot | Design |
| :--------: | :----: |
|            |        |
-->
