### PR TITLE
[TECH-1545] Parameterize staging and prod builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ workflows:
       - deploy:
           name: deploy-production
           requires:
-            - build
+            - build-production
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,21 +89,21 @@ workflows:
   build-and-deploy:
     jobs:
       - build:
-        name: build-staging
-        filters:
-          branches:
-            only: main
-        env: staging
-        is_indexing_allowed: false
-        is_local_cms_data_enabled: true
+          name: build-staging
+          filters:
+            branches:
+              only: main
+          env: staging
+          is_indexing_allowed: false
+          is_local_cms_data_enabled: true
       - build:
-        name: build-production
-        filters:
-          branches:
-            only: main
-        env: production
-        is_indexing_allowed: true
-        is_local_cms_data_enabled: false
+          name: build-production
+          filters:
+            branches:
+              only: main
+          env: production
+          is_indexing_allowed: true
+          is_local_cms_data_enabled: false
       - deploy:
           name: deploy-staging
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,22 @@ orbs:
 jobs:
   build:
     executor: node/default
+    parameters:
+      env:
+        type: enum
+        description: controls the environment to build for
+        enum: [
+          "staging",
+          "production",
+        ]
+      is_indexing_allowed:
+        type: boolean
+        description: Controls whether site crawling is enabled. When set to false a no-index tag is added to the site.
+        default: false
+      is_local_cms_data_enabled:
+        type: boolean
+        description: Controls whether the site is loaded using checked in config/ local data.
+        default: true
     steps:
       - checkout
       - node/install-packages:
@@ -20,6 +36,9 @@ jobs:
             DATADOG_SERVICE: marketing-website
             DATADOG_SITE: datadoghq.com
             STATIC_BUILD: true
+            NEXT_PUBLIC_ENV: << parameters.env >>
+            IS_INDEXING_ALLOWED: << parameters.is_indexing_allowed >>
+            IS_LOCAL_CMS_DATA_ENABLED: << parameters.is_local_cms_data_enabled >>
       - run:
           name: Run tests
           command: yarn test --passWithNoTests
@@ -69,11 +88,26 @@ jobs:
 workflows:
   build-and-deploy:
     jobs:
-      - build
+      - build:
+        name: build-staging
+        filters:
+          branches:
+            only: main
+        env: staging
+        is_indexing_allowed: false
+        is_local_cms_data_enabled: true
+      - build:
+        name: build-production
+        filters:
+          branches:
+            only: main
+        env: production
+        is_indexing_allowed: true
+        is_local_cms_data_enabled: false
       - deploy:
           name: deploy-staging
           requires:
-            - build
+            - build-staging
           filters:
             branches:
               only: main


### PR DESCRIPTION
- Cherry picks some functionality from https://github.com/fireflyhealth/marketing-website/pull/65/files
- Parameterizes the build step so that it can run the build step with different environment vars.
- Runs the staging and prod build with three new environment vars (none of which are used in the code right now)
  - NEXT_PUBLIC_ENV
  - IS_INDEXING_ALLOWED
  - IS_LOCAL_CMS_DATA_ENABLED