### PR TITLE
feat: add cms deploy before build staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,18 @@ orbs:
   aws-s3: circleci/aws-s3@4.0
 
 jobs:
+  deploy-cms:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn
+      - run:
+          name: Deploy Sanity CMS
+          command: cd sanity && SANITY_AUTH_TOKEN="${SANITY_AUTH_TOKEN}" yarn deploy
+          working_directory: ~/project/www
+
   build:
     executor: node/default
     parameters:
@@ -82,8 +94,15 @@ jobs:
 workflows:
   build-and-deploy:
     jobs:
+      - deploy-cms:
+          name: deploy-cms-schema-update
+          filters:
+            branches:
+              only: main
       - build:
           name: build-staging
+          requires:
+            - deploy-cms-schema-update
           filters:
             branches:
               only: main


### PR DESCRIPTION
### Description
deploy sanity before we build staging site

### Feedback & Concerns
Please make sure to add `SANITY_AUTH_TOKEN` on Circle CI env variable for this step to work. 
