### PR TITLE
feat: replace next-sitemap with generateSitemap

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -7,7 +7,7 @@
     "start": "next start",
     "build": "next build",
     "build:analyze": "ANALYZE=true next build",
-    "build:static": "NEXT_PUBLIC_STATIC_BUILD=true next build && next-sitemap && esno scripts/copyMissingBContent.ts",
+    "build:static": "NEXT_PUBLIC_STATIC_BUILD=true next build && esno scripts/copyMissingBContent.ts",
     "lint": "next lint",
     "test:all": "yarn test:prettier && yarn test:types && yarn test:lint && yarn test:queryByteLengths && yarn test:jest",
     "test:lint": "next lint",

--- a/www/src/lib/sanity/index.ts
+++ b/www/src/lib/sanity/index.ts
@@ -626,7 +626,7 @@ const SITEMAP_DATA_QUERY = `
 `;
 
 export const Sitemap = {
-  get(): Promise<SitemapData | null> {
+  get(): Promise<SitemapData> {
     return client.fetch(SITEMAP_DATA_QUERY);
   },
 };

--- a/www/src/pages/sitemap.xml.tsx
+++ b/www/src/pages/sitemap.xml.tsx
@@ -1,0 +1,103 @@
+import { GetServerSideProps } from 'next';
+import { SitemapData } from '@/lib/sanity';
+import { urlForDocument } from '@/utils/linking';
+
+import * as Sanity from '@/lib/sanity';
+
+const Sitemap = () => {
+  // getServerSideProps will do the heavy lifting
+};
+
+const generateSitemap = (sitemapData: SitemapData) => {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+      <url>
+        <loc>${urlForDocument(sitemapData.homepage)}</loc>
+        <lastmod>${sitemapData.homepage._updatedAt}</lastmod>
+      </url>
+      <url>
+        <loc>${urlForDocument(sitemapData.faqPage)}</loc>
+        <lastmod>${sitemapData.faqPage._updatedAt}</lastmod>
+      </url>
+      <url>
+        <loc>${urlForDocument(sitemapData.contactPage)}</loc>
+        <lastmod>${sitemapData.contactPage._updatedAt}</lastmod>
+      </url>
+      <url>
+        <loc>${urlForDocument(sitemapData.downloadPage)}</loc>
+        <lastmod>${sitemapData.downloadPage._updatedAt}</lastmod>
+      </url>
+      ${sitemapData.genericPage
+        .map(
+          (doc) => `
+          <url>
+            <loc>${urlForDocument(doc)}</loc>
+            <lastmod>${doc._updatedAt}</lastmod>
+          </url>`,
+        )
+        .join('')}
+      ${sitemapData.subPage
+        .map(
+          (doc) => `
+          <url>
+            <loc>${urlForDocument(doc)}</loc>
+            <lastmod>${doc._updatedAt}</lastmod>
+          </url>`,
+        )
+        .join('')}
+      ${sitemapData.blog
+        .map(
+          (doc) => `
+          <url>
+            <loc>${urlForDocument(doc)}</loc>
+            <lastmod>${doc._updatedAt}</lastmod>
+          </url>`,
+        )
+        .join('')}
+      ${sitemapData.blogArticle
+        .map(
+          (doc) => `
+          <url>
+            <loc>${urlForDocument(doc)}</loc>
+            <lastmod>${doc._updatedAt}</lastmod>
+          </url>`,
+        )
+        .join('')}
+      ${sitemapData.clientPage
+        .map(
+          (doc) => `
+          <url>
+            <loc>${urlForDocument(doc)}</loc>
+            <lastmod>${doc._updatedAt}</lastmod>
+          </url>`,
+        )
+        .join('')}
+      ${sitemapData.practitioner
+        .map(
+          (doc) => `
+          <url>
+            <loc>${urlForDocument(doc)}</loc>
+            <lastmod>${doc._updatedAt}</lastmod>
+          </url>`,
+        )
+        .join('')}
+    </urlset>
+  `;
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  const documents = await Sanity.Sitemap.get();
+
+  const sitemap = generateSitemap(documents);
+
+  res.setHeader('Content-Type', 'text/xml');
+  // we send the XML to the browser
+  res.write(sitemap);
+  res.end();
+
+  return {
+    props: {},
+  };
+};
+
+export default Sitemap;

--- a/www/src/utils/linking.ts
+++ b/www/src/utils/linking.ts
@@ -57,6 +57,35 @@ export const getLinkableDocumentPath = (doc: LinkableDocumentData): string => {
   }
 };
 
+export const urlForDocument = (doc: LinkableDocumentData): string => {
+  const BASE_URL =
+    process.env.NODE_ENV === 'development'
+      ? 'http://localhost:3000'
+      : 'https://www.fireflyhealth.com';
+  switch (doc._type) {
+    case 'homepage':
+      return BASE_URL;
+    case 'faqPage':
+      return `${BASE_URL}/faq`;
+    case 'contactPage':
+      return `${BASE_URL}/contact`;
+    case 'downloadPage':
+      return `${BASE_URL}/download`;
+    case 'genericPage':
+      return `${BASE_URL}/${doc.slug.current}`;
+    case 'subPage':
+      return `${BASE_URL}/${doc.parentPage.slug.current}/${doc.slug.current}`;
+    case 'blog':
+      return `${BASE_URL}/blog/${doc.slug.current}`;
+    case 'blogArticle':
+      return `${BASE_URL}/blog/${doc.category.slug.current}/${doc.slug.current}`;
+    case 'clientPage':
+      return `${BASE_URL}/with/${doc.slug.current}`;
+    case 'practitioner':
+      return `${BASE_URL}/care-team/${doc.slug.current}`;
+  }
+};
+
 /* Returns the full production URL for a linkable document */
 export const getLinkableDocumentProductionUrl = (
   doc: LinkableDocumentData,


### PR DESCRIPTION
### Description

- removes `next-sitemap` script and uses `generateSitemap` to dynamically build sitemap

Addresses [this maintenance ticket](https://www.notion.so/garden3d/a2ad8d447b914caa95ba0f01214ed512?v=69f7a661391d40eb966fce5affc5720c&p=04960b00d1de4e9ba390b9ef0f308860&pm=s)