### PR TITLE
feat: exclude b-content files from sitemap

### DIFF
--- a/www/next-sitemap.config.js
+++ b/www/next-sitemap.config.js
@@ -2,5 +2,6 @@
 module.exports = {
   siteUrl: 'https://www.fireflyhealth.com',
   generateRobotsTxt: true,
+  exclude: ['/*b-content'],
   outDir: './out',
 };


### PR DESCRIPTION
### Description

- Updates next-sitemap-config to exclude `b-content` URLs from Sitemap ([docs](https://www.npmjs.com/package/next-sitemap))

Addresses this [maintenance ticket](https://www.notion.so/garden3d/a2ad8d447b914caa95ba0f01214ed512?v=69f7a661391d40eb966fce5affc5720c&p=04960b00d1de4e9ba390b9ef0f308860&pm=s)

### Feedback & Concerns

- This PR replaces an earlier PR to replace the sitemap