### PR TITLE
feat: add manual blog list

### DIFF
--- a/www/src/hooks/useBlogArticlePagination.ts
+++ b/www/src/hooks/useBlogArticlePagination.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useReducer } from 'react';
 import { Status } from '@/constants';
 import * as sanity from '@/lib/sanity';
 import {
+  ArticleSortOrder,
   BlogArticlePagination,
   BlogArticleTagGroup,
   Maybe,
@@ -92,6 +93,7 @@ const reducer = (prevState: State, action: Action): State => {
 
 export const useBlogArticlePagination = (
   blogSlug: string,
+  sortOrder: ArticleSortOrder,
   initialPage: Maybe<BlogArticlePagination>,
   articleTag: Maybe<BlogArticleTagGroup>,
 ): ReturnValue => {
@@ -106,11 +108,13 @@ export const useBlogArticlePagination = (
   const fetchPage = useCallback(
     async (pageNumber: number) => {
       dispatch({ type: 'setPending' });
-      const fetchedNextPage = await sanity.blog.getBlogArticles(
-        blogSlug,
-        pageNumber,
-        tagSlug,
-      );
+      const fetchedNextPage =
+        sortOrder == 'sortManually'
+          ? await sanity.blog.getManuallySortedBlogArticles(
+              blogSlug,
+              pageNumber,
+            )
+          : await sanity.blog.getBlogArticles(blogSlug, pageNumber, tagSlug);
 
       dispatch({ type: 'goNext', nextPage: fetchedNextPage });
     },

--- a/www/src/hooks/useBlogArticlePagination.ts
+++ b/www/src/hooks/useBlogArticlePagination.ts
@@ -113,6 +113,7 @@ export const useBlogArticlePagination = (
           ? await sanity.blog.getManuallySortedBlogArticles(
               blogSlug,
               pageNumber,
+              tagSlug,
             )
           : await sanity.blog.getBlogArticles(blogSlug, pageNumber, tagSlug);
 

--- a/www/src/lib/sanity/index.ts
+++ b/www/src/lib/sanity/index.ts
@@ -474,7 +474,7 @@ export const blog = {
       $tagSlug in tags[]->slug.current
     )
     && ${isNotVariantFilter}
-  ] | order(_updatedAt desc) | order(publishDate desc) {
+  ] | order(updatedDate desc) | order(_updatedAt desc) | order(publishDate desc) {
     ${blogArticleLinkDataFragment}
   }[$from..$to]`,
       { blogSlug, from, to, tagSlug: tagSlug || null },

--- a/www/src/lib/sanity/index.ts
+++ b/www/src/lib/sanity/index.ts
@@ -501,10 +501,12 @@ export const blog = {
             && slug.current == $blogSlug
             && ${isNotVariantFilter}
           ][0]{
-            documentVariantInfo,
+            documentVariantInfo{
+              variantOf{...}
+            },
             manuallySortedArticleList[]->{
               ${blogArticleLinkDataFragment}
-            }
+            },
           }[$from..$to]`,
       { blogSlug, from, to },
     );

--- a/www/src/lib/sanity/index.ts
+++ b/www/src/lib/sanity/index.ts
@@ -490,6 +490,7 @@ export const blog = {
   getManuallySortedBlogArticles: async (
     blogSlug: string,
     page: number = 0,
+    tagSlug?: string,
   ): Promise<BlogArticlePagination> => {
     const from = page * PAGINATION_PAGE_SIZE;
     /* Overfetch by 1 to see if there are additional pages */
@@ -501,11 +502,11 @@ export const blog = {
             && slug.current == $blogSlug
             && ${isNotVariantFilter}
           ][0]{
-            manuallySortedArticleList[][$from..$to]->{
+            manuallySortedArticleList[$tagSlug == null || $tagSlug in @->tags[]-> slug.current][$from..$to] -> {
               ${blogArticleLinkDataFragment}
-            },
+            }
           }`,
-      { blogSlug, from, to },
+      { blogSlug, from, to, tagSlug: tagSlug || null },
     );
     const articles = blog?.manuallySortedArticleList || [];
     /* Slice off the possible over-fetched article */

--- a/www/src/lib/sanity/queries/fragments.ts
+++ b/www/src/lib/sanity/queries/fragments.ts
@@ -84,6 +84,7 @@ export const blogArticleLinkDataFragment = `
   slug,
   title,
   publishDate,
+  updatedDate,
   _updatedAt,
   thumbnail{
     ${imageFragment}

--- a/www/src/lib/sanity/queries/fragments.ts
+++ b/www/src/lib/sanity/queries/fragments.ts
@@ -95,6 +95,12 @@ export const blogArticleLinkDataFragment = `
     _type,
     slug,
     title
+  },
+  tags[]->{
+    title,
+    slug {
+      current
+    }
   }
 `;
 

--- a/www/src/lib/sanity/queries/fragments.ts
+++ b/www/src/lib/sanity/queries/fragments.ts
@@ -84,6 +84,7 @@ export const blogArticleLinkDataFragment = `
   slug,
   title,
   publishDate,
+  _updatedAt,
   thumbnail{
     ${imageFragment}
   },

--- a/www/src/lib/sanity/queries/index.ts
+++ b/www/src/lib/sanity/queries/index.ts
@@ -152,7 +152,6 @@ export const blogFragment = `
     ${blogArticleLinkDataFragment}
   },
   articleSortOrder,
-  manuallySortedArticleList[]->{${blogArticleLinkDataFragment}},
   contentArea[]{
     ${contentBlockFragment}
   },

--- a/www/src/lib/sanity/queries/index.ts
+++ b/www/src/lib/sanity/queries/index.ts
@@ -151,6 +151,8 @@ export const blogFragment = `
   featuredArticle->{
     ${blogArticleLinkDataFragment}
   },
+  articleSortOrder,
+  manuallySortedArticleList[]->{${blogArticleLinkDataFragment}},
   contentArea[]{
     ${contentBlockFragment}
   },

--- a/www/src/pages/blog/[blogSlug]/index.tsx
+++ b/www/src/pages/blog/[blogSlug]/index.tsx
@@ -5,10 +5,46 @@ import { PageProps } from '@/types/next';
 import { RevalidationTime } from '@/constants';
 
 import { BlogPageView } from '@/views/Blog/BlogPageView';
-import { Blog, BlogArticlePagination } from '@/types/sanity';
+import {
+  Maybe,
+  Blog,
+  BlogArticlePagination,
+  ArticleSortOrder,
+  BlogArticleLinkData,
+} from '@/types/sanity';
 import * as Sanity from '@/lib/sanity';
 import { BlogMetadata } from '@/components/Metadata/BlogMetadata';
 import { QueryConfig } from '@/lib/sanity';
+
+/**
+ * Sort articles by date
+ */
+const sortArticles = (
+  sortOrder: ArticleSortOrder,
+  initialArticlesPage: BlogArticlePagination,
+  manuallySortedArticleList: Maybe<BlogArticleLinkData[]>,
+) => {
+  if (sortOrder == 'sortManually' && manuallySortedArticleList) {
+    // const sortedInitialArticlesPage = initialArticlesPage.articles.filter(article => manuallySortedArticleList.filter(m => m.slug.current == article.slug.current))
+    initialArticlesPage.articles = manuallySortedArticleList;
+    return initialArticlesPage;
+  }
+
+  const sortedArticles = initialArticlesPage.articles.sort((a, b) => {
+    if (!!a._updatedAt && !!b._updatedAt) {
+      const dateA = new Date(a._updatedAt).getTime();
+      const dateB = new Date(b._updatedAt).getTime();
+
+      return dateB - dateA;
+    }
+
+    return NaN;
+  });
+
+  initialArticlesPage.articles = sortedArticles;
+
+  return initialArticlesPage;
+};
 
 export type BlogPageProps = PageProps & {
   blog: Blog;
@@ -19,7 +55,14 @@ const BlogPage: FC<BlogPageProps> = ({ blog, initialArticlesPage }) => {
   return (
     <>
       <BlogMetadata blog={blog} />
-      <BlogPageView blog={blog} initialArticlesPage={initialArticlesPage} />
+      <BlogPageView
+        blog={blog}
+        initialArticlesPage={sortArticles(
+          blog.articleSortOrder,
+          initialArticlesPage,
+          blog.manuallySortedArticleList,
+        )}
+      />
     </>
   );
 };

--- a/www/src/pages/blog/[blogSlug]/index.tsx
+++ b/www/src/pages/blog/[blogSlug]/index.tsx
@@ -5,46 +5,10 @@ import { PageProps } from '@/types/next';
 import { RevalidationTime } from '@/constants';
 
 import { BlogPageView } from '@/views/Blog/BlogPageView';
-import {
-  Maybe,
-  Blog,
-  BlogArticlePagination,
-  ArticleSortOrder,
-  BlogArticleLinkData,
-} from '@/types/sanity';
+import { Blog, BlogArticlePagination } from '@/types/sanity';
 import * as Sanity from '@/lib/sanity';
 import { BlogMetadata } from '@/components/Metadata/BlogMetadata';
 import { QueryConfig } from '@/lib/sanity';
-
-/**
- * Sort articles by date
- */
-const sortArticles = (
-  sortOrder: ArticleSortOrder,
-  initialArticlesPage: BlogArticlePagination,
-  manuallySortedArticleList: Maybe<BlogArticleLinkData[]>,
-) => {
-  if (sortOrder == 'sortManually' && manuallySortedArticleList) {
-    // const sortedInitialArticlesPage = initialArticlesPage.articles.filter(article => manuallySortedArticleList.filter(m => m.slug.current == article.slug.current))
-    initialArticlesPage.articles = manuallySortedArticleList;
-    return initialArticlesPage;
-  }
-
-  const sortedArticles = initialArticlesPage.articles.sort((a, b) => {
-    if (!!a._updatedAt && !!b._updatedAt) {
-      const dateA = new Date(a._updatedAt).getTime();
-      const dateB = new Date(b._updatedAt).getTime();
-
-      return dateB - dateA;
-    }
-
-    return NaN;
-  });
-
-  initialArticlesPage.articles = sortedArticles;
-
-  return initialArticlesPage;
-};
 
 export type BlogPageProps = PageProps & {
   blog: Blog;
@@ -55,14 +19,7 @@ const BlogPage: FC<BlogPageProps> = ({ blog, initialArticlesPage }) => {
   return (
     <>
       <BlogMetadata blog={blog} />
-      <BlogPageView
-        blog={blog}
-        initialArticlesPage={sortArticles(
-          blog.articleSortOrder,
-          initialArticlesPage,
-          blog.manuallySortedArticleList,
-        )}
-      />
+      <BlogPageView blog={blog} initialArticlesPage={initialArticlesPage} />
     </>
   );
 };
@@ -80,11 +37,15 @@ export const createGetStaticProps =
       throw new Error('blogSlug param is not a string');
     }
 
-    const [siteSettings, blog, initialArticlesPage] = await Promise.all([
+    const [siteSettings, blog] = await Promise.all([
       Sanity.siteSettings.get(),
       Sanity.blog.get(blogSlug, config),
-      Sanity.blog.getBlogArticles(blogSlug),
     ]);
+
+    const initialArticlesPage =
+      blog?.articleSortOrder == 'sortManually'
+        ? await Sanity.blog.getManuallySortedBlogArticles(blogSlug)
+        : await Sanity.blog.getBlogArticles(blogSlug);
 
     const navigationOverrides = blog?.navigationOverrides;
 

--- a/www/src/types/sanity.ts
+++ b/www/src/types/sanity.ts
@@ -280,6 +280,8 @@ export type PractitionerLinkData = Pick<
   | 'renderProviderPage'
 >;
 
+export type ArticleSortOrder = 'sortAutomatically' | 'sortManually';
+
 /* Blogs */
 export type Blog = SanityDocument & {
   _type: 'blog';
@@ -289,6 +291,8 @@ export type Blog = SanityDocument & {
   navigationOverrides?: NavigationOverrides;
   header: HeaderArea;
   featuredArticle?: Maybe<BlogArticle>;
+  articleSortOrder: ArticleSortOrder;
+  manuallySortedArticleList?: Maybe<BlogArticleLinkData[]>;
   contentArea?: Maybe<ContentArea>;
   allArticlesLabel: string;
   blogArticleTagGroups?: Maybe<KeyedArray<BlogArticleTagGroup>>;

--- a/www/src/types/sanity.ts
+++ b/www/src/types/sanity.ts
@@ -292,11 +292,14 @@ export type Blog = SanityDocument & {
   header: HeaderArea;
   featuredArticle?: Maybe<BlogArticle>;
   articleSortOrder: ArticleSortOrder;
-  manuallySortedArticleList?: Maybe<BlogArticleLinkData[]>;
   contentArea?: Maybe<ContentArea>;
   allArticlesLabel: string;
   blogArticleTagGroups?: Maybe<KeyedArray<BlogArticleTagGroup>>;
   articleLayout: BlogArticleLayout;
+};
+
+export type ManuallySortedBlogArticle = {
+  manuallySortedArticleList?: Maybe<BlogArticleLinkData[]>;
 };
 
 /* Used when generating slug params. For

--- a/www/src/types/sanity.ts
+++ b/www/src/types/sanity.ts
@@ -280,7 +280,7 @@ export type PractitionerLinkData = Pick<
   | 'renderProviderPage'
 >;
 
-export type ArticleSortOrder = 'sortAutomatically' | 'sortManually';
+export type ArticleSortOrder = 'sortAutomatically' | 'sortManually' | undefined;
 
 /* Blogs */
 export type Blog = SanityDocument & {
@@ -353,6 +353,7 @@ export type BlogArticleLinkData = Pick<
   | 'publishDate'
   | 'blurb'
   | '_updatedAt'
+  | 'tags'
 >;
 
 /* Blog article pagination */
@@ -360,6 +361,14 @@ export type BlogArticlePagination = {
   page: number;
   hasNextPage: boolean;
   articles: BlogArticleLinkData[];
+};
+
+export type ManuallySortedBlogArticlePagination = {
+  page: number;
+  hasNextPage: boolean;
+  articles: {
+    manuallySortedArticleList: BlogArticleLinkData[];
+  }[];
 };
 
 /* Navigation */

--- a/www/src/views/Blog/BlogArticlesGrid.tsx
+++ b/www/src/views/Blog/BlogArticlesGrid.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import cn from 'classnames';
-import { BlogArticleLinkData } from '@/types/sanity';
+import { ArticleSortOrder, BlogArticleLinkData } from '@/types/sanity';
 import { SanityImage } from '@/atoms/Image/SanityImage';
 import { formatSanityDate } from '@/utils/text';
 import { Link } from '@/atoms/Link';
@@ -31,12 +31,13 @@ const BlogArticlesGridItem: FC<BlogArticlesGridItemProps> = ({ article }) => {
   );
 };
 
-export const BlogArticlesGrid: FC<BlogArticlesSharedProps> = ({
-  currentPage,
-}) => {
+export const BlogArticlesGrid: FC<
+  BlogArticlesSharedProps & { sortOrder: ArticleSortOrder }
+> = ({ currentPage, sortOrder }) => {
   /** TODO: Maybe add skeletons here. However, users will only see an empty state
    * if they switch to an article tab *very quickly* after initial load. */
   if (!currentPage) return null;
+  // const sortedArticles = sortArticles(sortOrder, currentPage.articles);
   return (
     <div className={cn(BlogArticlesGridWrapper)}>
       {currentPage.articles.map((article) => (

--- a/www/src/views/Blog/BlogArticlesGrid.tsx
+++ b/www/src/views/Blog/BlogArticlesGrid.tsx
@@ -1,6 +1,11 @@
 import React, { FC } from 'react';
 import cn from 'classnames';
-import { ArticleSortOrder, BlogArticleLinkData } from '@/types/sanity';
+import {
+  Maybe,
+  ArticleSortOrder,
+  BlogArticleLinkData,
+  BlogArticleTagGroup,
+} from '@/types/sanity';
 import { SanityImage } from '@/atoms/Image/SanityImage';
 import { formatSanityDate } from '@/utils/text';
 import { Link } from '@/atoms/Link';
@@ -32,12 +37,15 @@ const BlogArticlesGridItem: FC<BlogArticlesGridItemProps> = ({ article }) => {
 };
 
 export const BlogArticlesGrid: FC<
-  BlogArticlesSharedProps & { sortOrder: ArticleSortOrder }
-> = ({ currentPage, sortOrder }) => {
+  BlogArticlesSharedProps & {
+    sortOrder: ArticleSortOrder;
+    articleTag: Maybe<BlogArticleTagGroup>;
+    manuallySortedArticleList?: Maybe<BlogArticleLinkData[]>;
+  }
+> = ({ currentPage }) => {
   /** TODO: Maybe add skeletons here. However, users will only see an empty state
    * if they switch to an article tab *very quickly* after initial load. */
   if (!currentPage) return null;
-  // const sortedArticles = sortArticles(sortOrder, currentPage.articles);
   return (
     <div className={cn(BlogArticlesGridWrapper)}>
       {currentPage.articles.map((article) => (

--- a/www/src/views/Blog/BlogArticlesGrid.tsx
+++ b/www/src/views/Blog/BlogArticlesGrid.tsx
@@ -36,13 +36,9 @@ const BlogArticlesGridItem: FC<BlogArticlesGridItemProps> = ({ article }) => {
   );
 };
 
-export const BlogArticlesGrid: FC<
-  BlogArticlesSharedProps & {
-    sortOrder: ArticleSortOrder;
-    articleTag: Maybe<BlogArticleTagGroup>;
-    manuallySortedArticleList?: Maybe<BlogArticleLinkData[]>;
-  }
-> = ({ currentPage }) => {
+export const BlogArticlesGrid: FC<BlogArticlesSharedProps> = ({
+  currentPage,
+}) => {
   /** TODO: Maybe add skeletons here. However, users will only see an empty state
    * if they switch to an article tab *very quickly* after initial load. */
   if (!currentPage) return null;

--- a/www/src/views/Blog/BlogArticlesGrid.tsx
+++ b/www/src/views/Blog/BlogArticlesGrid.tsx
@@ -46,6 +46,7 @@ export const BlogArticlesGrid: FC<
   /** TODO: Maybe add skeletons here. However, users will only see an empty state
    * if they switch to an article tab *very quickly* after initial load. */
   if (!currentPage) return null;
+
   return (
     <div className={cn(BlogArticlesGridWrapper)}>
       {currentPage.articles.map((article) => (

--- a/www/src/views/Blog/BlogPageArticles.tsx
+++ b/www/src/views/Blog/BlogPageArticles.tsx
@@ -151,7 +151,6 @@ export const BlogPageArticles: FC<BlogPageArticlesProps> = ({
       goNext={goNext}
       goPrev={goPrev}
       sortOrder={blog.articleSortOrder}
-      manuallySortedArticleList={blog.manuallySortedArticleList}
       articleTag={articleTag}
     />
   );

--- a/www/src/views/Blog/BlogPageArticles.tsx
+++ b/www/src/views/Blog/BlogPageArticles.tsx
@@ -6,6 +6,7 @@ import {
   BlogArticleLayout,
   BlogArticlePagination,
   BlogArticleTagGroup,
+  BlogArticleLinkData,
   Maybe,
 } from '@/types/sanity';
 import { Status } from '@/constants';
@@ -21,6 +22,8 @@ type BlogPageArticlesInnerProps = {
   articleLayout: BlogArticleLayout;
   paginationStatus: Status;
   sortOrder: ArticleSortOrder;
+  manuallySortedArticleList?: Maybe<BlogArticleLinkData[]>;
+  articleTag?: Maybe<BlogArticleTagGroup>;
 };
 
 /* The inner UI, which does not deal with fetching the data itself.
@@ -32,6 +35,8 @@ export const BlogPageArticlesInner: FC<BlogPageArticlesInnerProps> = ({
   articleLayout,
   paginationStatus,
   sortOrder,
+  manuallySortedArticleList,
+  articleTag,
 }) => {
   const blogArticlesRef = useRef<HTMLDivElement>(null);
   const scrollToArticlesTop = () => {
@@ -78,7 +83,12 @@ export const BlogPageArticlesInner: FC<BlogPageArticlesInnerProps> = ({
         {articleLayout === 'list' ? (
           <BlogArticlesList currentPage={currentPage} />
         ) : (
-          <BlogArticlesGrid sortOrder={sortOrder} currentPage={currentPage} />
+          <BlogArticlesGrid
+            currentPage={currentPage}
+            articleTag={articleTag}
+            sortOrder={sortOrder}
+            manuallySortedArticleList={manuallySortedArticleList}
+          />
         )}
       </div>
       {hasMultiplePages ? (
@@ -126,10 +136,13 @@ export const BlogPageArticles: FC<BlogPageArticlesProps> = ({
 }) => {
   const { state, goNext, goPrev } = useBlogArticlePagination(
     blog.slug.current,
+    blog.articleSortOrder,
     initialArticlesPage,
     articleTag,
   );
   const { currentPage } = state;
+
+  if (!currentPage) return;
   return (
     <BlogPageArticlesInner
       paginationStatus={state.status}
@@ -138,6 +151,8 @@ export const BlogPageArticles: FC<BlogPageArticlesProps> = ({
       goNext={goNext}
       goPrev={goPrev}
       sortOrder={blog.articleSortOrder}
+      manuallySortedArticleList={blog.manuallySortedArticleList}
+      articleTag={articleTag}
     />
   );
 };

--- a/www/src/views/Blog/BlogPageArticles.tsx
+++ b/www/src/views/Blog/BlogPageArticles.tsx
@@ -2,6 +2,7 @@ import React, { FC, useRef } from 'react';
 import cn from 'classnames';
 import {
   Blog,
+  ArticleSortOrder,
   BlogArticleLayout,
   BlogArticlePagination,
   BlogArticleTagGroup,
@@ -19,6 +20,7 @@ type BlogPageArticlesInnerProps = {
   goPrev: () => Promise<void>;
   articleLayout: BlogArticleLayout;
   paginationStatus: Status;
+  sortOrder: ArticleSortOrder;
 };
 
 /* The inner UI, which does not deal with fetching the data itself.
@@ -29,6 +31,7 @@ export const BlogPageArticlesInner: FC<BlogPageArticlesInnerProps> = ({
   goPrev,
   articleLayout,
   paginationStatus,
+  sortOrder,
 }) => {
   const blogArticlesRef = useRef<HTMLDivElement>(null);
   const scrollToArticlesTop = () => {
@@ -75,7 +78,7 @@ export const BlogPageArticlesInner: FC<BlogPageArticlesInnerProps> = ({
         {articleLayout === 'list' ? (
           <BlogArticlesList currentPage={currentPage} />
         ) : (
-          <BlogArticlesGrid currentPage={currentPage} />
+          <BlogArticlesGrid sortOrder={sortOrder} currentPage={currentPage} />
         )}
       </div>
       {hasMultiplePages ? (
@@ -134,6 +137,7 @@ export const BlogPageArticles: FC<BlogPageArticlesProps> = ({
       currentPage={currentPage}
       goNext={goNext}
       goPrev={goPrev}
+      sortOrder={blog.articleSortOrder}
     />
   );
 };

--- a/www/src/views/Blog/BlogPageArticles.tsx
+++ b/www/src/views/Blog/BlogPageArticles.tsx
@@ -83,12 +83,7 @@ export const BlogPageArticlesInner: FC<BlogPageArticlesInnerProps> = ({
         {articleLayout === 'list' ? (
           <BlogArticlesList currentPage={currentPage} />
         ) : (
-          <BlogArticlesGrid
-            currentPage={currentPage}
-            articleTag={articleTag}
-            sortOrder={sortOrder}
-            manuallySortedArticleList={manuallySortedArticleList}
-          />
+          <BlogArticlesGrid currentPage={currentPage} />
         )}
       </div>
       {hasMultiplePages ? (
@@ -143,6 +138,7 @@ export const BlogPageArticles: FC<BlogPageArticlesProps> = ({
   const { currentPage } = state;
 
   if (!currentPage) return;
+
   return (
     <BlogPageArticlesInner
       paginationStatus={state.status}

--- a/www/src/views/Blog/BlogPageView.tsx
+++ b/www/src/views/Blog/BlogPageView.tsx
@@ -19,6 +19,7 @@ export const BlogPageView: FC<BlogPageViewProps> = ({
 }) => {
   const { header, featuredArticle, contentArea } = blog;
   const blogArticleTagGroups = blog.blogArticleTagGroups || [];
+
   return (
     <div>
       <HeaderArea block={header} />
@@ -47,7 +48,7 @@ export const BlogPageView: FC<BlogPageViewProps> = ({
             },
             ...blogArticleTagGroups.map((tagGroup) => ({
               _key: tagGroup._key,
-              label: tagGroup.tag.title,
+              label: tagGroup.title || tagGroup.tag.title,
               children: (
                 <BlogPageArticles
                   blog={blog}

--- a/www/src/views/Blog/__tests__/BlogPageArticles.test.tsx
+++ b/www/src/views/Blog/__tests__/BlogPageArticles.test.tsx
@@ -53,6 +53,7 @@ describe('BlogPageArticles', () => {
     const { queryByText } = render(
       <BlogPageArticlesInner
         articleLayout="list"
+        sortOrder="sortAutomatically"
         paginationStatus={Status.Idle}
         goNext={goNext}
         goPrev={goPrev}
@@ -70,6 +71,7 @@ describe('BlogPageArticles', () => {
     const { rerender, getByText } = render(
       <BlogPageArticlesInner
         articleLayout="list"
+        sortOrder="sortAutomatically"
         paginationStatus={Status.Idle}
         goNext={goNext}
         goPrev={goPrev}
@@ -93,6 +95,7 @@ describe('BlogPageArticles', () => {
     rerender(
       <BlogPageArticlesInner
         articleLayout="list"
+        sortOrder="sortAutomatically"
         paginationStatus={Status.Pending}
         goNext={goNext}
         goPrev={goPrev}
@@ -110,6 +113,7 @@ describe('BlogPageArticles', () => {
     rerender(
       <BlogPageArticlesInner
         articleLayout="list"
+        sortOrder="sortAutomatically"
         paginationStatus={Status.Fulfilled}
         goNext={goNext}
         goPrev={goPrev}


### PR DESCRIPTION
### Description

- adds sorting feature to `blog` schema
- sorts articles based on the selection editors make in Sanity ("Manually" or "Automatically by last updated")

Addresses this [maintenance ticket](https://www.notion.so/garden3d/a2ad8d447b914caa95ba0f01214ed512?v=69f7a661391d40eb966fce5affc5720c&p=69ef77b6ceac4e74ad49effad421031d&pm=s) 

### Feedback & Concerns

<!-- List any concerns/details/gotchas with your changes here or call them out as pr comments. -->

### QA Instructions

<!--- If you'd like reviewers to test locally, please add steps here -->

### Applicable screenshots or Loom video
![Screenshot 2024-11-07 at 5 35 14 PM](https://github.com/user-attachments/assets/74029607-962a-44b0-8efb-9143fb5be3ec)
![Screenshot 2024-11-07 at 5 36 04 PM](https://github.com/user-attachments/assets/842410e1-331d-4632-9c5b-76b675d3eddf)
![Screenshot 2024-11-07 at 5 35 28 PM](https://github.com/user-attachments/assets/8ca0a144-aafe-4bbc-9e07-b7c6fe2373ea)
![Screenshot 2024-11-07 at 5 35 52 PM](https://github.com/user-attachments/assets/8e1902c7-3a91-4f7e-bf1c-3b812b03f107)