### PR TITLE
feat: add article eyebrow text

### DIFF
--- a/sanity/schemas/documents/blogArticle.tsx
+++ b/sanity/schemas/documents/blogArticle.tsx
@@ -34,6 +34,11 @@ export const BlogArticle = defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
+      name: 'eyebrow',
+      title: 'Eyebrow',
+      type: 'string',
+    }),
+    defineField({
       name: 'articleImage',
       title: 'Article Image',
       description:

--- a/sanity/schemas/documents/blogArticle.tsx
+++ b/sanity/schemas/documents/blogArticle.tsx
@@ -28,10 +28,11 @@ export const BlogArticle = defineType({
       },
     }),
     defineField({
-      name: 'title',
-      title: 'Title',
-      type: 'string',
-      validation: (Rule) => Rule.required(),
+      name: 'articleImage',
+      title: 'Article Image',
+      description:
+        'Used in article header if image is provided. Otherwise, article header will render without image.',
+      type: 'richImage',
     }),
     defineField({
       name: 'eyebrow',
@@ -39,11 +40,10 @@ export const BlogArticle = defineType({
       type: 'string',
     }),
     defineField({
-      name: 'articleImage',
-      title: 'Article Image',
-      description:
-        'Used in article header if image is provided. Otherwise, article header will render without image.',
-      type: 'richImage',
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       name: 'publishDate',

--- a/www/src/components/ArticleHeader/index.tsx
+++ b/www/src/components/ArticleHeader/index.tsx
@@ -50,8 +50,15 @@ const ArticleTag = ({
 };
 
 export const ArticleHeader: FC<Props> = ({ articleHeader }) => {
-  const { tags, title, authorName, publishDate, updatedDate, articleImage } =
-    articleHeader;
+  const {
+    tags,
+    title,
+    eyebrow,
+    authorName,
+    publishDate,
+    updatedDate,
+    articleImage,
+  } = articleHeader;
   const selectedPublishedDate = publishDate;
   const formattedPublishDate = formatSanityDate(selectedPublishedDate);
   return (
@@ -63,6 +70,9 @@ export const ArticleHeader: FC<Props> = ({ articleHeader }) => {
       >
         <ArticleTag tags={tags} />
         <h1 className={cn('font-size-4 font-trust')}>{title}</h1>
+        {eyebrow && (
+          <p className="font-size-8--cta font-roobert mt-6">{eyebrow}</p>
+        )}
         <div className={cn(Info)}>
           {authorName && <p className={cn(Author)}>by {authorName}</p>}
           <div className={cn(DateWrapper)}>

--- a/www/src/components/ArticleHeader/index.tsx
+++ b/www/src/components/ArticleHeader/index.tsx
@@ -69,10 +69,10 @@ export const ArticleHeader: FC<Props> = ({ articleHeader }) => {
         })}
       >
         <ArticleTag tags={tags} />
-        <h1 className={cn('font-size-4 font-trust')}>{title}</h1>
         {eyebrow && (
-          <p className="font-size-8--cta font-roobert mt-6">{eyebrow}</p>
+          <p className="font-size-8--cta font-roobert mb-6">{eyebrow}</p>
         )}
+        <h1 className={cn('font-size-4 font-trust')}>{title}</h1>
         <div className={cn(Info)}>
           {authorName && <p className={cn(Author)}>by {authorName}</p>}
           <div className={cn(DateWrapper)}>

--- a/www/src/lib/sanity/queries/index.ts
+++ b/www/src/lib/sanity/queries/index.ts
@@ -117,6 +117,7 @@ export const faqPageFragment = `
 export const blogArticleFragment = `
   _id,
   title,
+  eyebrow,
   category->{
     _type,
     title,

--- a/www/src/types/sanity.ts
+++ b/www/src/types/sanity.ts
@@ -324,7 +324,7 @@ export type BlogArticleTag = SanityDocument & {
 export type BlogArticle = SanityDocument & {
   _type: 'blogArticle';
   title: string;
-  eyebrow: string;
+  eyebrow: Maybe<string>;
   publishDate: string;
   updatedDate?: Maybe<string>;
   articleImage?: Maybe<RichImage>;

--- a/www/src/types/sanity.ts
+++ b/www/src/types/sanity.ts
@@ -324,6 +324,7 @@ export type BlogArticleTag = SanityDocument & {
 export type BlogArticle = SanityDocument & {
   _type: 'blogArticle';
   title: string;
+  eyebrow: string;
   publishDate: string;
   updatedDate?: Maybe<string>;
   articleImage?: Maybe<RichImage>;


### PR DESCRIPTION
### Description

Adds optional eyebrow to blog articles

Addresses [this maintenance ticket](https://www.notion.so/garden3d/a2ad8d447b914caa95ba0f01214ed512?v=69f7a661391d40eb966fce5affc5720c&p=ab29dfbc0cc24341a93cdeda6decf9cc&pm=s)

### Applicable screenshots or Loom video
![image](https://github.com/user-attachments/assets/4575baf6-cac4-49d8-bbae-f9e4fedff2ac)
![image](https://github.com/user-attachments/assets/a886ed6b-fdd7-4f65-b228-4083272058b7)

