### PR TITLE
feat: add noindex tag to client page

### DIFF
--- a/www/src/components/Metadata/ClientMetadata.tsx
+++ b/www/src/components/Metadata/ClientMetadata.tsx
@@ -5,13 +5,10 @@ import { GenericMetadata } from './GenericMetadata';
 
 type ClientMetadataProps = {
   metadata?: Metadata;
-  clientPage: ClientPage;
 };
 
-export const ClientMetadata: FC<ClientMetadataProps> = ({
-  metadata,
-  clientPage,
-}) => {
-  // TODO: add sensible metadata fallbacks from page content
-  return <GenericMetadata {...metadata} />;
+export const ClientMetadata: FC<ClientMetadataProps> = ({ metadata }) => {
+  // Client page should not show up in search results.
+  // So we set noIndex to true.
+  return <GenericMetadata {...metadata} noIndex={true} />;
 };

--- a/www/src/pages/with/[clientSlug]/index.tsx
+++ b/www/src/pages/with/[clientSlug]/index.tsx
@@ -39,7 +39,7 @@ const ClientPage: FC<ClientPageProps> = ({ siteSettings, clientPage }) => {
         />
       ) : (
         <>
-          <ClientMetadata clientPage={clientPage} />
+          <ClientMetadata />
           <ClientPageView clientPage={clientPage} />
         </>
       )}

--- a/www/src/views/JPMCView/index.tsx
+++ b/www/src/views/JPMCView/index.tsx
@@ -36,6 +36,7 @@ export const JPMCVIew: FC<Props> = ({
   return (
     <>
       <Head>
+        <meta key="robots-noindex" name="robots" content="noindex" />
         <meta charSet="utf-8" />
         <title>
           Digital-first Primary Care | JPMorgan Chase and Firefly Health


### PR DESCRIPTION
### Description
add no index tag on client pages

Closes # [no index tag on client pages](https://www.notion.so/garden3d/No-Index-tag-on-client-pages-5d616a5eccf84500be6c0736c1a7e026?pvs=4)

### Feedback & Concerns

<!-- List any concerns/details/gotchas with your changes here or call them out as pr comments. -->

### QA Instructions
navigate to client pages and we should see "no-index" tag

### Applicable screenshots or Loom video
![image](https://github.com/user-attachments/assets/4e69029a-4349-40f1-ba8a-99c95a16b6e0)
![image](https://github.com/user-attachments/assets/7edc1178-5506-4072-a957-b3748399f2dc)

<!--- When appropriate, upload screenshots or link to a Loom. -->

<!--
for frontend PRs, you can use this table to put screengrabs & figma designs side-by-side. This can be a chore but is great for catching things you might have missed!

Github will insert line breaks when you paste in an image, so you'll need to do a bit of reformatting to get it to look like:

| <img width="350" ...> | <img width="350" ...> |

Tip: Set the "width" attribute manually to force column widths to match
-->

<!--
| Screenshot | Design |
| :--------: | :----: |
|            |        |
-->
